### PR TITLE
表示エラーの修正

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,6 +5,7 @@ class CommentsController < ApplicationController
     if @comment.save
       redirect_to prototype_path(@prototype)
     else
+      @comments = @prototype.comments.includes(:user)
       render template: "prototypes/show"
     end
   end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,5 @@
 class PrototypesController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @prototypes = Prototype.all
@@ -26,7 +26,7 @@ class PrototypesController < ApplicationController
 
   def edit
     @prototype = Prototype.find(params[:id])
-    unless user_signed_in?
+    unless user_signed_in? && current_user.id == @prototype.user_id
       redirect_to action: :index
     end
   end
@@ -43,7 +43,7 @@ class PrototypesController < ApplicationController
   def destroy
     prototype = Prototype.find(params[:id])
     prototype.destroy
-    render :index
+    redirect_to root_path
   end
 
   private


### PR DESCRIPTION
## 表示エラーの修正
- コメントフォームを空の状態で送信した際のエラー
- ログアウト状態での投稿の閲覧不可
- 投稿削除後の表示の調整
- ログイン状態で他のユーザー投稿の編集不可機能
